### PR TITLE
active/standby support + fixes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,26 +3,27 @@ before:
   hooks:
     - go mod tidy
 builds:
-- targets: [go_first_class]
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    # trims path
-    - -trimpath
-  ldflags:
-    # use commit date instead of current date as main.date
-    # only needed if you actually use those things in your main package, otherwise can be ignored.
-    - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }}
+  - targets: [go_first_class]
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      # trims path
+      - -trimpath
+    ldflags:
+      # use commit date instead of current date as main.date
+      # only needed if you actually use those things in your main package, otherwise can be ignored.
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }}
+env:
+  - CGO_ENABLED=0
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"
 
 release:
-  name_template: 'v{{ .Version }}'
-  
+  name_template: "v{{ .Version }}"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # commvault-go-exporter
 Prometheus exporter for Commvault
+
+
+## Run Exporter
+
+    Usage:
+      commvault-go-exporter [flags]
+
+    Flags:
+      -e, --endpoint string   Commvault endpoint
+      -h, --help              help for commvault-go-exporter
+          --insecure          Skip SSL certificate verification
+      -p, --password string   Password to connect to Commvault
+      -l, --port int16        Port the metricserver will listen on (default 2112)
+      -u, --user string       Username to connect to Commvault
+  
+#### example
+
+    commvault-go-exporter --endpoint https://cs01.example.com --user testuser
+    commvault-go-exporter --port 3000 --endpoint https://cs01.example.com --user testuser --password supersecure
+
+## Metrics
+
+    curl localhost:2112/metrics

--- a/client/client.go
+++ b/client/client.go
@@ -52,7 +52,7 @@ func NewClient(target string, username string, password string, insecure bool) (
 	}
 
 	if username == "" || password == "" {
-		return nil, fmt.Errorf("[error] Must specify API token or both username and password")
+		return nil, fmt.Errorf("[error] Must specify username and password")
 	}
 
 	// cookieJar, _ := cookiejar.New(nil)

--- a/client/client.go
+++ b/client/client.go
@@ -213,12 +213,19 @@ func (c *CommvaultClient) renewTokenExecutor(ctx context.Context) {
 				continue
 			}
 		case <-c.tokenManualTrigger:
-			fmt.Printf("[info] Start renew token (manual trigger)\n")
-			err := c.RenewToken()
-			if err != nil {
-				fmt.Printf("[error]: failed to renew token\n%+v\n", err)
-				continue
+			for i := 100; i > 0; i-- {
+				fmt.Printf("[info] Start renew token (manual trigger)\n")
+				err := c.RenewToken()
+				if err != nil {
+					fmt.Printf("[error]: failed to renew token\n%+v\n", err)
+					time.Sleep(3 * time.Second)
+					continue
+				} else {
+					fmt.Println("[info]: renew token successfull")
+					break
+				}
 			}
+
 		case <-c.tokenFlushTrigger:
 			c.FlushToken()
 			fmt.Printf("[info] Flush token\n")

--- a/client/client_status.go
+++ b/client/client_status.go
@@ -1,0 +1,135 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type ClientStatusService struct {
+	client        *CommvaultClient
+	isActive      bool
+	isActiveLock  sync.Mutex
+	checkPeriod   time.Duration
+	ticker        *time.Ticker
+	lastCheckTime time.Time
+}
+
+func NewClientStatusService(client *CommvaultClient, period time.Duration) *ClientStatusService {
+	return &ClientStatusService{
+		client:       client,
+		checkPeriod:  period,
+		isActiveLock: sync.Mutex{},
+		isActive:     false,
+		ticker:       time.NewTicker(period),
+	}
+}
+
+func (c *ClientStatusService) GetIsActive() bool {
+	c.isActiveLock.Lock()
+	defer c.isActiveLock.Unlock()
+	return c.isActive
+}
+
+func (c *ClientStatusService) GetStatus() ClientStatus {
+	c.isActiveLock.Lock()
+	defer c.isActiveLock.Unlock()
+	return ClientStatus{
+		IsActive:        c.GetIsActive(),
+		LastStatusCheck: c.lastCheckTime,
+	}
+}
+
+func (c *ClientStatusService) SetStatus(active bool) {
+	c.isActiveLock.Lock()
+	defer c.isActiveLock.Unlock()
+	c.isActive = active
+}
+
+func (c *ClientStatusService) Start(ctx context.Context) {
+	go c.executor(ctx)
+}
+
+func (c *ClientStatusService) Stop(ctx context.Context) {
+	c.ticker.Stop()
+}
+
+func (c *ClientStatusService) executor(ctx context.Context) {
+	for {
+		select {
+		case <-c.ticker.C:
+			err := c.CheckStatus()
+			if err != nil {
+				fmt.Printf("[error]: failed to check API endpoint status\n%+v\n", err)
+				continue
+			}
+			var s string
+			if c.GetIsActive() {
+				s = "Active"
+			} else {
+				s = "Standby"
+			}
+			fmt.Printf("[info] Commvault API status: %s\n", s)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (c *ClientStatusService) CheckStatus() error {
+	baseUrl, err := c.client.Url(nil, nil)
+	if err != nil {
+		return err
+	}
+
+	var port int
+	if port, err = strconv.Atoi(baseUrl.Port()); err != nil || port == 0 {
+		if baseUrl.Scheme == "http" {
+			port = 80
+		} else if baseUrl.Scheme == "https" {
+			port = 443
+		} else {
+			return fmt.Errorf("invalid port number")
+		}
+	}
+
+	fmt.Printf("[debug] Status check: %s:%d\n", baseUrl.Hostname(), port)
+	var previousStatus bool
+	// conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", baseUrl.Hostname(), port))
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", baseUrl.Hostname(), port), 3*time.Second)
+	previousStatus = c.isActive
+	if err != nil {
+		c.SetStatus(false)
+		fmt.Printf("[debug] Status check: failed\n")
+	} else {
+		c.SetStatus(true)
+		fmt.Printf("[debug] Status check: successfull\n")
+	}
+
+	if previousStatus && !c.isActive {
+		fmt.Println("[debug] Trigger token flush")
+		go func() {
+			c.client.tokenFlushTrigger <- true
+		}()
+
+	} else if !previousStatus && c.isActive {
+		fmt.Println("[debug] Trigger token renewal")
+		go func() {
+			c.client.tokenManualTrigger <- true
+		}()
+	}
+
+	defer func() {
+		if conn != nil {
+			err := conn.Close()
+			if err != nil {
+				fmt.Printf("failed to close connection: %s\n", err)
+			}
+		}
+	}()
+
+	return nil
+}

--- a/client/client_statusTypes.go
+++ b/client/client_statusTypes.go
@@ -1,0 +1,8 @@
+package client
+
+import "time"
+
+type ClientStatus struct {
+	IsActive        bool
+	LastStatusCheck time.Time
+}

--- a/client/storage.go
+++ b/client/storage.go
@@ -45,7 +45,7 @@ func (c *StorageService) GetLibrariesDetails() ([]LibraryDetail, error) {
 	}
 
 	for _, lib := range libs {
-		req, err := c.client.NewXmlRequest("GET", fmt.Sprintf("/webconsole/api/Library/%d", lib.Id), nil, nil)
+		req, err := c.client.NewRequest("GET", fmt.Sprintf("/webconsole/api/Library/%d", lib.Id), nil, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/exporter/db_status.go
+++ b/exporter/db_status.go
@@ -58,6 +58,10 @@ func (collector *DbStatusCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *DbStatusCollector) Collect(ch chan<- prometheus.Metric) {
+	if !collector.commvaultClient.GetActiveStatus() {
+		return
+	}
+
 	dbInstance, err := collector.commvaultClient.Database.GetDatabaseInstances()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[error] %v", err)

--- a/exporter/db_status.go
+++ b/exporter/db_status.go
@@ -58,22 +58,21 @@ func (collector *DbStatusCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *DbStatusCollector) Collect(ch chan<- prometheus.Metric) {
-	if collector.commvaultClient.Status != nil && !collector.commvaultClient.Status.GetIsActive() && collector.commvaultClient.GetToken() != "" {
-		return
+	if collector.commvaultClient.IsActive() {
+		dbInstance, err := collector.commvaultClient.Database.GetDatabaseInstances()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[error] %v", err)
+			return
+		}
+		for _, dbi := range dbInstance {
+			labels := []string{dbi.Instance.ClientName, dbi.Instance.AppName, dbi.Instance.InstanceName, dbi.Instance.EntityInfo.CompanyName}
+			ch <- prometheus.MustNewConstMetric(collector.lastBackupEndTime, prometheus.GaugeValue, float64(dbi.LastBackupJobInfo.EndTime.Time), labels...)
+			ch <- prometheus.MustNewConstMetric(collector.lastBackupStartTime, prometheus.GaugeValue, float64(dbi.LastBackupJobInfo.StartTime.Time), labels...)
+			ch <- prometheus.MustNewConstMetric(collector.lastBackupJobStatus, prometheus.GaugeValue, float64(dbi.LastBackupJobInfo.Status), labels...)
+			ch <- prometheus.MustNewConstMetric(collector.slaStatus, prometheus.GaugeValue, float64(dbi.SLAStatus), labels...)
+			ch <- prometheus.MustNewConstMetric(collector.applicationSize, prometheus.GaugeValue, float64(dbi.ApplicationSize), labels...)
+			ch <- prometheus.MustNewConstMetric(collector.backupSize, prometheus.GaugeValue, float64(dbi.BackupSize), labels...)
+		}
 	}
 
-	dbInstance, err := collector.commvaultClient.Database.GetDatabaseInstances()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "[error] %v", err)
-		return
-	}
-	for _, dbi := range dbInstance {
-		labels := []string{dbi.Instance.ClientName, dbi.Instance.AppName, dbi.Instance.InstanceName, dbi.Instance.EntityInfo.CompanyName}
-		ch <- prometheus.MustNewConstMetric(collector.lastBackupEndTime, prometheus.GaugeValue, float64(dbi.LastBackupJobInfo.EndTime.Time), labels...)
-		ch <- prometheus.MustNewConstMetric(collector.lastBackupStartTime, prometheus.GaugeValue, float64(dbi.LastBackupJobInfo.StartTime.Time), labels...)
-		ch <- prometheus.MustNewConstMetric(collector.lastBackupJobStatus, prometheus.GaugeValue, float64(dbi.LastBackupJobInfo.Status), labels...)
-		ch <- prometheus.MustNewConstMetric(collector.slaStatus, prometheus.GaugeValue, float64(dbi.SLAStatus), labels...)
-		ch <- prometheus.MustNewConstMetric(collector.applicationSize, prometheus.GaugeValue, float64(dbi.ApplicationSize), labels...)
-		ch <- prometheus.MustNewConstMetric(collector.backupSize, prometheus.GaugeValue, float64(dbi.BackupSize), labels...)
-	}
 }

--- a/exporter/db_status.go
+++ b/exporter/db_status.go
@@ -58,13 +58,14 @@ func (collector *DbStatusCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *DbStatusCollector) Collect(ch chan<- prometheus.Metric) {
-	if !collector.commvaultClient.GetActiveStatus() {
+	if collector.commvaultClient.Status != nil && !collector.commvaultClient.Status.GetIsActive() && collector.commvaultClient.GetToken() != "" {
 		return
 	}
 
 	dbInstance, err := collector.commvaultClient.Database.GetDatabaseInstances()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[error] %v", err)
+		return
 	}
 	for _, dbi := range dbInstance {
 		labels := []string{dbi.Instance.ClientName, dbi.Instance.AppName, dbi.Instance.InstanceName, dbi.Instance.EntityInfo.CompanyName}

--- a/exporter/fs_backup.go
+++ b/exporter/fs_backup.go
@@ -29,9 +29,10 @@ func (collector *FsBackupStatusCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *FsBackupStatusCollector) Collect(ch chan<- prometheus.Metric) {
-	if !collector.commvaultClient.GetActiveStatus() {
+	if collector.commvaultClient.Status != nil && !collector.commvaultClient.Status.GetIsActive() && collector.commvaultClient.GetToken() != "" {
 		return
 	}
+
 	bclients, err := collector.commvaultClient.Bkp.GetBkpClients()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[ERROR] Failed to get the clients\n%s\n", err)

--- a/exporter/fs_backup.go
+++ b/exporter/fs_backup.go
@@ -29,6 +29,9 @@ func (collector *FsBackupStatusCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *FsBackupStatusCollector) Collect(ch chan<- prometheus.Metric) {
+	if !collector.commvaultClient.GetActiveStatus() {
+		return
+	}
 	bclients, err := collector.commvaultClient.Bkp.GetBkpClients()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[ERROR] Failed to get the clients\n%s\n", err)

--- a/exporter/status.go
+++ b/exporter/status.go
@@ -1,0 +1,33 @@
+package exporter
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"gitlab.global.ingenico.com/sdescamps/commvault-go-exporter/client"
+)
+
+type StatusCollector struct {
+	commvaultClient *client.CommvaultClient
+	commvaultStatus *prometheus.Desc
+}
+
+func NewCommvaultStatusCollector(client *client.CommvaultClient) *StatusCollector {
+	return &StatusCollector{
+		commvaultClient: client,
+		commvaultStatus: prometheus.NewDesc(prometheus.BuildFQName(namespace, "status", "is_active"),
+			"is Commvault API active",
+			[]string{}, nil,
+		),
+	}
+}
+
+func (collector *StatusCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- collector.commvaultStatus
+}
+
+func (collector *StatusCollector) Collect(ch chan<- prometheus.Metric) {
+	if collector.commvaultClient.GetActiveStatus() {
+		ch <- prometheus.MustNewConstMetric(collector.commvaultStatus, prometheus.GaugeValue, 1)
+	} else {
+		ch <- prometheus.MustNewConstMetric(collector.commvaultStatus, prometheus.GaugeValue, 0)
+	}
+}

--- a/exporter/status.go
+++ b/exporter/status.go
@@ -25,7 +25,7 @@ func (collector *StatusCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *StatusCollector) Collect(ch chan<- prometheus.Metric) {
-	if collector.commvaultClient.GetActiveStatus() {
+	if collector.commvaultClient.Status != nil && collector.commvaultClient.Status.GetIsActive() {
 		ch <- prometheus.MustNewConstMetric(collector.commvaultStatus, prometheus.GaugeValue, 1)
 	} else {
 		ch <- prometheus.MustNewConstMetric(collector.commvaultStatus, prometheus.GaugeValue, 0)

--- a/exporter/storage.go
+++ b/exporter/storage.go
@@ -172,13 +172,14 @@ func (collector *StorageDiskCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *StorageDiskCollector) Collect(ch chan<- prometheus.Metric) {
-	if !collector.commvaultClient.GetActiveStatus() {
+	if collector.commvaultClient.Status != nil && !collector.commvaultClient.Status.GetIsActive() && collector.commvaultClient.GetToken() != "" {
 		return
 	}
 
 	storageDetails, err := collector.commvaultClient.Storage.GetLibrariesDetails()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[error] %v", err)
+		return
 	}
 	for _, sd := range storageDetails {
 		var libTyp string

--- a/exporter/storage.go
+++ b/exporter/storage.go
@@ -172,6 +172,10 @@ func (collector *StorageDiskCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *StorageDiskCollector) Collect(ch chan<- prometheus.Metric) {
+	if !collector.commvaultClient.GetActiveStatus() {
+		return
+	}
+
 	storageDetails, err := collector.commvaultClient.Storage.GetLibrariesDetails()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[error] %v", err)

--- a/exporter/vm_status.go
+++ b/exporter/vm_status.go
@@ -63,12 +63,14 @@ func (collector *VmStatusCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *VmStatusCollector) Collect(ch chan<- prometheus.Metric) {
-	if !collector.commvaultClient.GetActiveStatus() {
+	if collector.commvaultClient.Status != nil && !collector.commvaultClient.Status.GetIsActive() && collector.commvaultClient.GetToken() != "" {
 		return
 	}
+
 	vmStatus, err := collector.commvaultClient.Vm.GetVmStatus(client.VmStatus_All)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[error] %v", err)
+		return
 	}
 	for _, vm := range *vmStatus {
 		labels := []string{vm.Name, vm.Plan.PlanName, vm.SubclientName, vm.StrGUID}

--- a/exporter/vm_status.go
+++ b/exporter/vm_status.go
@@ -63,6 +63,9 @@ func (collector *VmStatusCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *VmStatusCollector) Collect(ch chan<- prometheus.Metric) {
+	if !collector.commvaultClient.GetActiveStatus() {
+		return
+	}
 	vmStatus, err := collector.commvaultClient.Vm.GetVmStatus(client.VmStatus_All)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[error] %v", err)

--- a/main.go
+++ b/main.go
@@ -67,7 +67,6 @@ func main() {
 	rootCmd.PersistentFlags().StringP("endpoint", "e", "", "Commvault endpoint")
 	rootCmd.PersistentFlags().StringP("user", "u", "", "Username to connect to Commvault")
 	rootCmd.PersistentFlags().StringP("password", "p", "", "Password to connect to Commvault")
-	rootCmd.PersistentFlags().StringP("token", "t", "", "Token to connect to Commvault")
 	rootCmd.PersistentFlags().Bool("insecure", false, "Skip SSL certificate verification")
 	rootCmd.MarkFlagsRequiredTogether("user", "password")
 	rootCmd.MarkFlagsMutuallyExclusive("user", "token")

--- a/main.go
+++ b/main.go
@@ -61,95 +61,6 @@ var runCmd = &cobra.Command{
 	},
 }
 
-var testCmd = &cobra.Command{
-	Use:   "test",
-	Short: "Print the version number of Hugo",
-	Long:  `All software has versions. This is Hugo's`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("this is just a test")
-	},
-}
-
-var test2Cmd = &cobra.Command{
-	Use:   "test2",
-	Short: "Print the version number of Hugo",
-	Long:  `All software has versions. This is Hugo's`,
-	Run: func(cmd *cobra.Command, args []string) {
-
-		commvaultTarget, _ := cmd.Flags().GetString("endpoint")
-		username, _ := cmd.Flags().GetString("user")
-		password, _ := cmd.Flags().GetString("password")
-		insecure, _ := cmd.Flags().GetBool("insecure")
-
-		// var client client.CommvaultClient
-		client, err := client.NewClient(commvaultTarget, username, password, insecure)
-		if err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", err)
-			os.Exit(1)
-		}
-
-		bclients, err := client.Bkp.GetBkpClients()
-		if err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", err)
-			os.Exit(1)
-		}
-		for _, bc := range bclients {
-			fmt.Printf("CLIENT clientId=%d hostname: %s company=%s\n", bc.Client.ClientEntity.ClientID, bc.Client.ClientEntity.HostName, bc.Client.ClientEntity.EntityInfo.CompanyName)
-
-			bagents, err := client.Bkp.GetBkpAgents(uint64(bc.Client.ClientEntity.ClientID))
-			if err != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", err)
-				os.Exit(1)
-			}
-			for _, ba := range bagents {
-				fmt.Printf("AGENT clientId=%d clientName='%s' appName='%s' applicationId=%d\n", ba.IdaEntity.ClientID, ba.IdaEntity.ClientName, ba.IdaEntity.AppName, ba.IdaEntity.ApplicationID)
-			}
-
-			binstances, err := client.Bkp.GetBkpInstancesByClientId(uint64(bc.Client.ClientEntity.ClientID))
-			if err != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", err)
-				os.Exit(1)
-			}
-			for _, bi := range binstances {
-				fmt.Printf("INSTANCE appName='%s' applicationSize=%d applicationId=%d\n", bi.Instance.AppName, bi.ApplicationSize, bi.Instance.ApplicationID)
-			}
-
-		}
-
-	},
-}
-
-var test3Cmd = &cobra.Command{
-	Use:   "test3",
-	Short: "Print the version number of Hugo",
-	Long:  `All software has versions. This is Hugo's`,
-	Run: func(cmd *cobra.Command, args []string) {
-
-		commvaultTarget, _ := cmd.Flags().GetString("endpoint")
-		username, _ := cmd.Flags().GetString("user")
-		password, _ := cmd.Flags().GetString("password")
-		insecure, _ := cmd.Flags().GetBool("insecure")
-
-		// var client client.CommvaultClient
-		client, err := client.NewClient(commvaultTarget, username, password, insecure)
-		if err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", err)
-			os.Exit(1)
-		}
-
-		fmt.Printf("------------------\n")
-		dbs2, err := client.Database.GetDatabaseInstances()
-		if err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", err)
-			os.Exit(1)
-		}
-
-		for _, db := range dbs2 {
-			fmt.Printf("%s\n", db.Instance.ClientName)
-		}
-	},
-}
-
 func main() {
 	var rootCmd = &cobra.Command{Use: "app"}
 	rootCmd.PersistentFlags().Int16P("port", "l", 2112, "Port the metricserver will listen on")
@@ -163,7 +74,7 @@ func main() {
 	rootCmd.MarkFlagsMutuallyExclusive("password", "token")
 	// #nosec G104
 	rootCmd.MarkFlagRequired("endpoint")
-	rootCmd.AddCommand(runCmd, testCmd, test2Cmd, test3Cmd)
+	rootCmd.AddCommand(runCmd)
 	// #nosec G104
 	rootCmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -81,7 +81,9 @@ func main() {
 	rootCmd.MarkFlagsRequiredTogether("user", "password")
 	// #nosec G104
 	rootCmd.MarkFlagRequired("endpoint")
+	// #nosec G104
 	rootCmd.MarkFlagRequired("user")
+	// #nosec G104
 	rootCmd.MarkFlagRequired("password")
 	rootCmd.AddCommand(runCmd)
 	// #nosec G104

--- a/main.go
+++ b/main.go
@@ -44,7 +44,8 @@ var runCmd = &cobra.Command{
 		storageCollector := exporter.NewStorageDiskCollector(client)
 		fsBackupCollector := exporter.NewFsBackupStatusCollector(client)
 		dbStatusCollector := exporter.NewDbStatusCollector(client)
-		prometheus.MustRegister(vmStatusCollector, storageCollector, fsBackupCollector, dbStatusCollector)
+		statusCollector := exporter.NewCommvaultStatusCollector(client)
+		prometheus.MustRegister(statusCollector, vmStatusCollector, storageCollector, fsBackupCollector, dbStatusCollector)
 
 		http.Handle("/metrics", promhttp.Handler())
 		fmt.Printf("Starting server on 0.0.0.0:%d....\n", tcpport)


### PR DESCRIPTION
This PR adds support for active/standby commcell endpoints. Only an exporter which is running on an active endpoint will be able to export all the Commvault metrics. The other one will only export some basic metrics and a status metric. Whenever an failover is triggered, the exporter will change status and adapt the metrics it collects. 